### PR TITLE
fixing Video Recording not working on Linux SDK

### DIFF
--- a/src/raw_record/ZoomSDKRendererDelegate.h
+++ b/src/raw_record/ZoomSDKRendererDelegate.h
@@ -52,6 +52,7 @@ public:
     void onRawDataFrameReceived(YUVRawDataI420* data) override;
     void onRawDataStatusChanged(RawDataStatus status) override {};
     void onRendererBeDestroyed() override {};
+    void SaveToRawYUVFile(YUVRawDataI420* data);
 };
 
 


### PR DESCRIPTION
So when I tried to use the bot for video recording the code kept failing 
it said falid to write data with code error 139 
after more digging the code uses old implementation for recording the video that isn't supported by 
the new linux SDK so i changed it to the new one 
I only edited two files: 
* ZoomSDKRendererDelegate.cpp
* ZoomSDKRenderDelegate.h
I hope you accept this pull request so that other people will benefit. 